### PR TITLE
Include missing cfloat

### DIFF
--- a/src/EEDI3CL.h
+++ b/src/EEDI3CL.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cfloat>
+
 #include "avisynth_c.h"
 #include "VCL2/vectorclass.h"
 


### PR DESCRIPTION
Missing include for cfloat (FLT_MAX, etc).